### PR TITLE
Change code to type for Product\Image

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -128,7 +128,8 @@ final class SearchController
         if ($this->isHtmlRequest($request)) {
             $view->setTemplate($this->getTemplateFromRequest($request));
         }
-        $taxon = $this->taxonRepository->findOneBySlug($slug);
+        $locale = $this->shopperContext->getLocaleCode();
+        $taxon = $this->taxonRepository->findOneBySlug($slug, $locale);
 
         $form = $this->formFactory->create(
             FilterSetType::class,

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -81,7 +81,7 @@ fos_elastica:
                             type: "nested"
                             properties:
                                 path: { type: string }
-                                code: { type: string }
+                                type: { type: string }
                         enabled: { type: boolean }
                         isSimple: { type: boolean }
                     persistence:


### PR DESCRIPTION
Fix error when populate database with last master

`[Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException] Neither the property "code" nor one of the methods "getCode()", "code()", "isCode()", "hasCode()", "__get()" exist and have public access in class "Sylius\Component\Core\Model\ProductImage".                  `                                  